### PR TITLE
Read domain from the env variable

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,7 +13,7 @@ config = {
     // When running Ghost in the wild, use the production environment.
     // Configure your URL and mail settings here
     production: {  
-        url: '',
+        url: process.env.SITE_URL,
         mail: {
     		transport: 'SMTP',
     		options: {


### PR DESCRIPTION
> At the moment the domain is hard coded to ghost.dokku.me, it'd be nice if ghost code was aware of the domain dokku/nginx is pointing at it and update accordingly.

Currently there's no way to determine a domain from the container (at least until we get the first request), so probably it would be nice to read it from the env variable. This would make the setup process look like this:

```
$ dokku clone ghost https://github.com/crisward/dokku-ghost.git
$ dokku config:set dokku SITE_URL=http://ghost.my.dokku.domain.example.org
```
